### PR TITLE
Login ${param.error} when credentials are wrong

### DIFF
--- a/src/main/java/app/controllers/RoutingController.java
+++ b/src/main/java/app/controllers/RoutingController.java
@@ -88,11 +88,11 @@ public class RoutingController {
                 ctx.sessionAttribute("customerId", userId);
                 showIndexPage(ctx);
             } else {
-                ctx.redirect("/login");
+                ctx.redirect("/login?error=wrongcredentials");
             }
         } catch (DatabaseException e) {
             e.printStackTrace();
-            ctx.redirect("/login");
+            ctx.redirect("/login?error=somethingwentwrong404");
         }
 
     }

--- a/src/main/resources/public/css/stylesloginregister.css
+++ b/src/main/resources/public/css/stylesloginregister.css
@@ -21,6 +21,16 @@ body {
     margin: 0;
 }
 
+.error-message {
+    position: absolute;
+    top: 300px;
+    left: 0;
+    color: red;
+    font-weight: bold;
+    width: 100%;
+    text-align: center;
+}
+
 .shopping-cart-icon {
     height: 75px;
     width: auto;

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -34,11 +34,14 @@
                    placeholder="Password"
                    name="password"
                    required>
-
+            <div class="error-container">
+                <div th:if="${param.error}">
+                    <p class="error-message">Forkert brugernavn eller adgangskode</p>
+                </div>
+            </div>
             <div class="form-footer">
                 <p>Hvis du ikke har en konto, så registrer dig <a th:href="@{/signup}" class="register-link">her</a></p>
             </div>
-
             <div class="login-form-button">
                 <a th:href="@{/index}" class="back-button">Back</a>
                 <button type="submit" class="login-button">LogInd</button>


### PR DESCRIPTION
When login with wrong credentials, it now displays "Forkert brugernavn eller adgangskode" with red under the input fields

also changed the url handling

       } else {
                ctx.redirect("/login?error=wrongcredentials");
            }
        } catch (DatabaseException e) {
            e.printStackTrace();
            ctx.redirect("/login?error=somethingwentwrong404");
        }